### PR TITLE
virtio blk fixes

### DIFF
--- a/virtio-blk.c
+++ b/virtio-blk.c
@@ -158,7 +158,7 @@ virtioblk_transfer(struct virtio_device *dev, char *buf, uint64_t blocknum,
 	current_used_idx = &vq->used->idx;
 
 	/* Set up header */
-	fill_blk_hdr(&blkhdr, dev->features, type | VIRTIO_BLK_T_BARRIER,
+	fill_blk_hdr(&blkhdr, dev->features, type,
 		     1, blocknum * blk_size / DEFAULT_SECTOR_SIZE);
 
 	/* Determine descriptor index */

--- a/virtio-blk.h
+++ b/virtio-blk.h
@@ -62,11 +62,6 @@ struct virtio_blk_req {
 /* Block request types */
 #define VIRTIO_BLK_T_IN			0
 #define VIRTIO_BLK_T_OUT		1
-#define VIRTIO_BLK_T_SCSI_CMD		2
-#define VIRTIO_BLK_T_SCSI_CMD_OUT	3
-#define VIRTIO_BLK_T_FLUSH		4
-#define VIRTIO_BLK_T_FLUSH_OUT		5
-#define VIRTIO_BLK_T_BARRIER		0x80000000
 
 /* VIRTIO_BLK Feature bits */
 #define VIRTIO_BLK_F_BLK_SIZE       (1 << 6)


### PR DESCRIPTION
- Remove legacy-only and not-negotiated request types and stop using them.
- Only query `blk_size` if the feature was negotiated